### PR TITLE
Refactor: move board creation logic into serializer

### DIFF
--- a/kanban_app/api/serializers.py
+++ b/kanban_app/api/serializers.py
@@ -1,12 +1,14 @@
 from rest_framework import serializers
 from kanban_app.models import Board
+from django.contrib.auth.models import User
 
 class BoardSerializer(serializers.ModelSerializer):
-    owner_id = serializers.IntegerField(source='owner.id')
+    owner_id = serializers.IntegerField(source='owner.id', read_only=True)
     member_count = serializers.SerializerMethodField()
     ticket_count = serializers.SerializerMethodField()
     tasks_to_do_count = serializers.SerializerMethodField()
     tasks_high_prio_count = serializers.SerializerMethodField()
+    members = serializers.ListField(write_only=True, child=serializers.IntegerField(), required=False)
 
     class Meta:
         model = Board
@@ -17,17 +19,30 @@ class BoardSerializer(serializers.ModelSerializer):
             'member_count',
             'ticket_count',
             'tasks_to_do_count',
-            'tasks_high_prio_count'
+            'tasks_high_prio_count',
+            'members'
         ]
 
     def get_member_count(self, obj):
         return obj.members.count()
 
     def get_ticket_count(self, obj):
-        return 0  # Task-Modell noch nicht vorhanden
+        return 0
 
     def get_tasks_to_do_count(self, obj):
         return 0
 
     def get_tasks_high_prio_count(self, obj):
         return 0
+    
+    def create(self, validated_data):
+        request = self.context.get('request')
+        user = request.user
+
+        members_ids = validated_data.pop('members', [])
+        if user.id not in members_ids:
+            members_ids.append(user.id)
+
+        board = Board.objects.create(title=validated_data['title'], owner=user)
+        board.members.set(User.objects.filter(id__in=members_ids))
+        return board

--- a/kanban_app/api/views.py
+++ b/kanban_app/api/views.py
@@ -5,7 +5,6 @@ from rest_framework import status
 from kanban_app.models import Board
 from .serializers import BoardSerializer
 from django.db.models import Q
-from django.contrib.auth.models import User
 
 
 class BoardListView(APIView):
@@ -18,22 +17,8 @@ class BoardListView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
     
     def post(self, request):
-        user = request.user
-        title = request.data.get('title')
-        members = request.data.get('members', [])
-
-        if not title:
-            return Response({'error': 'Title is required.'}, status=status.HTTP_400_BAD_REQUEST)
-
-        board = Board.objects.create(title=title, owner=user)
-        print(f"Board erstellt: '{board.title}' von User-ID {user.id}")
-
-        if user.id not in members:
-            members.append(user.id)
-
-        board.members.set(User.objects.filter(id__in=members))
-        print(f"Mitglieder hinzugefügt: {members}")
-
-        serializer = BoardSerializer(board)
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
-
+        serializer = BoardSerializer(data=request.data, context={'request': request})
+        if serializer.is_valid():
+            board = serializer.save()
+            return Response(BoardSerializer(board).data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## What was changed?
- Refactored the `POST /api/boards/` endpoint to follow DRF best practices
- Moved board creation logic out of the view and into the `BoardSerializer.create()` method
- Added `members` as a `write_only` ListField to allow passing member IDs during board creation

## Why?
- To reduce logic in the view and improve separation of concerns
- To make the view simpler, cleaner, and easier to test
- To enable potential reuse of board creation logic elsewhere (e.g., other views or admin tools)

## Additional Notes
- Duplicated member IDs are automatically ignored by `.set(...)`
- The authenticated user is always added as a member
- The field `members` is excluded from the response using `write_only=True`
