### PR TITLE
Implement GET with board_id

### DIFF
--- a/kanban_app/api/serializers.py
+++ b/kanban_app/api/serializers.py
@@ -46,3 +46,25 @@ class BoardSerializer(serializers.ModelSerializer):
         board = Board.objects.create(title=validated_data['title'], owner=user)
         board.members.set(User.objects.filter(id__in=members_ids))
         return board
+    
+class MemberSerializer(serializers.ModelSerializer):
+    fullname = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ['id', 'email', 'fullname']
+
+    def get_fullname(self, obj):
+        return f"{obj.first_name} {obj.last_name}".strip()
+
+class BoardDetailSerializer(serializers.ModelSerializer):
+    owner_id = serializers.IntegerField(source='owner.id')
+    members = MemberSerializer(many=True)
+    tasks = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Board
+        fields = ['id', 'title', 'owner_id', 'members', 'tasks']
+
+    def get_tasks(self, obj):
+        return []

--- a/kanban_app/api/urls.py
+++ b/kanban_app/api/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import BoardListView
+from .views import BoardListView, BoardDetailView
 
 urlpatterns = [
     path('boards/', BoardListView.as_view(), name='board-list'),
+    path('boards/<int:board_id>/', BoardDetailView.as_view(), name='board-detail'),
 ]

--- a/kanban_app/api/views.py
+++ b/kanban_app/api/views.py
@@ -3,7 +3,9 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import status
 from kanban_app.models import Board
-from .serializers import BoardSerializer
+from .serializers import BoardSerializer, BoardDetailSerializer
+from django.shortcuts import get_object_or_404
+from rest_framework.exceptions import PermissionDenied
 from django.db.models import Q
 
 
@@ -22,3 +24,15 @@ class BoardListView(APIView):
             board = serializer.save()
             return Response(BoardSerializer(board).data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+class BoardDetailView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, board_id):
+        board = get_object_or_404(Board, id=board_id)
+
+        if request.user != board.owner and request.user not in board.members.all():
+            raise PermissionDenied("You do not have access to this board.")
+
+        serializer = BoardDetailSerializer(board)
+        return Response(serializer.data)


### PR DESCRIPTION
## What was added?
- Implemented the detail view for a single board using `GET /api/boards/{board_id}/`
- Returns board data with:
  - id, title, owner_id
  - list of members (id, email, fullname)
  - list of tasks (currently empty placeholder)

## Permissions
- Only the board owner or members can access the endpoint
- Returns 403 if unauthorized, 404 if board does not exist

## Notes
- `fullname` is dynamically generated from `first_name` + `last_name`
- Tasks will be implemented later
