### PR TITLE
Patch with proper response

### DIFF
--- a/kanban_app/api/views.py
+++ b/kanban_app/api/views.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import status
 from kanban_app.models import Board
-from .serializers import BoardSerializer, BoardDetailSerializer
+from .serializers import BoardSerializer, BoardDetailSerializer, BoardUpdateSerializer
 from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import PermissionDenied
 from django.db.models import Q
@@ -36,3 +36,17 @@ class BoardDetailView(APIView):
 
         serializer = BoardDetailSerializer(board)
         return Response(serializer.data)
+    
+    def patch(self, request, board_id):
+        board = get_object_or_404(Board, id=board_id)
+
+        if request.user != board.owner and request.user not in board.members.all():
+            raise PermissionDenied("You do not have access to modify this board.")
+
+        serializer = BoardUpdateSerializer(board, data=request.data, partial=True, context={'request': request})
+        if serializer.is_valid():
+            serializer.save()
+            updated_board = Board.objects.get(id=board.id)
+            response_serializer = BoardDetailSerializer(updated_board)
+            return Response(response_serializer.data, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## What was added?
- Implemented board update via `PATCH /api/boards/{board_id}/`
- Allows changing the board title and member list
- Returns updated board data with:
  - id, title, owner_id
  - list of members (id, email, fullname)
  - empty task list placeholder

## Permissions
- Only the board owner or members can update the board
- Returns 403 if unauthorized, 404 if board does not exist

## Notes
- Members not included in the new list will be removed
- Response uses `BoardDetailSerializer` to match `GET` detail structure
