### PR TITLE
Delete_board

### DIFF
--- a/kanban_app/api/views.py
+++ b/kanban_app/api/views.py
@@ -50,3 +50,12 @@ class BoardDetailView(APIView):
             response_serializer = BoardDetailSerializer(updated_board)
             return Response(response_serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+    def delete(self, request, board_id):
+        board = get_object_or_404(Board, id=board_id)
+
+        if request.user != board.owner:
+            raise PermissionDenied("Only the board owner can delete this board.")
+
+        board.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## What was added?
- Implemented board deletion via `DELETE /api/boards/{board_id}/`
- Deletes the board and all associated tasks and comments

## Permissions
- Only the board owner is allowed to delete the board
- Returns 403 if the user is not the owner
- Returns 404 if the board does not exist

## Notes
- Response returns 204 No Content on success
- Request body must be empty
