### PR TITLE
Implement assigned-to-me task

### DIFF
--- a/kanban_app/api/serializers.py
+++ b/kanban_app/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from kanban_app.models import Board
+from kanban_app.models import Board, Task
 from django.contrib.auth.models import User
 
 class BoardSerializer(serializers.ModelSerializer):
@@ -91,3 +91,33 @@ class BoardUpdateSerializer(serializers.ModelSerializer):
 
     def get_members_data(self, obj):
         return MemberSerializer(obj.members.all(), many=True).data
+    
+
+class TaskUserSerializer(serializers.ModelSerializer):
+    fullname = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ['id', 'email', 'fullname']
+
+    def get_fullname(self, obj):
+        return f"{obj.first_name} {obj.last_name}".strip()
+
+class TaskSerializer(serializers.ModelSerializer):
+    assignee = TaskUserSerializer(read_only=True)
+    reviewer = TaskUserSerializer(read_only=True)
+
+    class Meta:
+        model = Task
+        fields = [
+            'id',
+            'board',
+            'title',
+            'description',
+            'status',
+            'priority',
+            'assignee',
+            'reviewer',
+            'due_date',
+            'comments_count'
+        ]

--- a/kanban_app/api/urls.py
+++ b/kanban_app/api/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import BoardListView, BoardDetailView, EmailCheckView
+from .views import BoardListView, BoardDetailView, EmailCheckView, TasksAssignedToMeView
 
 urlpatterns = [
     path('boards/', BoardListView.as_view(), name='board-list'),
     path('boards/<int:board_id>/', BoardDetailView.as_view(), name='board-detail'),
     path('email-check/', EmailCheckView.as_view(), name='email-check'),
+    path('tasks/assigned-to-me/', TasksAssignedToMeView.as_view(), name='tasks-assigned-to-me'),
 ]

--- a/kanban_app/api/views.py
+++ b/kanban_app/api/views.py
@@ -3,11 +3,12 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import status
 from kanban_app.models import Board
-from .serializers import BoardSerializer, BoardDetailSerializer, BoardUpdateSerializer
+from .serializers import BoardSerializer, BoardDetailSerializer, BoardUpdateSerializer, TaskSerializer
 from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import PermissionDenied
 from django.db.models import Q
 from django.contrib.auth import get_user_model
+from kanban_app.models import Task
 
 User = get_user_model()
 class BoardListView(APIView):
@@ -82,3 +83,12 @@ class EmailCheckView(APIView):
             'email': user.email,
             'fullname': fullname
         }, status=status.HTTP_200_OK)
+
+class TasksAssignedToMeView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        user = request.user
+        tasks = Task.objects.filter(assignee=user)
+        serializer = TaskSerializer(tasks, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/kanban_app/models.py
+++ b/kanban_app/models.py
@@ -8,3 +8,21 @@ class Board(models.Model):
 
     def __str__(self):
         return self.title
+    
+class Task(models.Model):
+    board = models.ForeignKey(Board, on_delete=models.CASCADE, related_name='tasks')
+    title = models.CharField(max_length=100)
+    description = models.TextField(blank=True)
+    status = models.CharField(max_length=20, choices=[('to-do', 'To Do'), ('in-progress', 'In Progress'), ('review', 'Review'), ('done', 'Done')])
+    priority = models.CharField(max_length=10, choices=[('low', 'Low'), ('medium', 'Medium'), ('high', 'High')])
+    assignee = models.ForeignKey(User, null=True, blank=True, related_name='assigned_tasks', on_delete=models.SET_NULL)
+    reviewer = models.ForeignKey(User, null=True, blank=True, related_name='reviewed_tasks', on_delete=models.SET_NULL)
+    due_date = models.DateField(null=True, blank=True)
+
+    def __str__(self):
+        return self.title
+
+    @property
+    def comments_count(self):
+        return 0
+


### PR DESCRIPTION
## What was added?
- Implemented `GET /api/tasks/assigned-to-me/` endpoint
- Returns all tasks where the authenticated user is the assignee

## Permissions
- Only accessible to authenticated users
- Returns 401 if not authenticated

## Responses
- 200 OK with a list of tasks assigned to the current user
- Each task includes: `id`, `title`, `description`, `status`, `prior
