### PR TITLE
Implement POST /api/tasks/ endpoint to create new task

### DIFF
--- a/kanban_app/api/urls.py
+++ b/kanban_app/api/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
-from .views import BoardListView, BoardDetailView, EmailCheckView, TasksAssignedToMeView
+from .views import BoardListView, BoardDetailView, EmailCheckView, TasksAssignedToMeView, TasksReviewingView, TaskCreateView
 
 urlpatterns = [
     path('boards/', BoardListView.as_view(), name='board-list'),
     path('boards/<int:board_id>/', BoardDetailView.as_view(), name='board-detail'),
     path('email-check/', EmailCheckView.as_view(), name='email-check'),
     path('tasks/assigned-to-me/', TasksAssignedToMeView.as_view(), name='tasks-assigned-to-me'),
+    path("tasks/reviewing/", TasksReviewingView.as_view(), name="tasks-reviewing"),
+    path("tasks/", TaskCreateView.as_view(), name="task-create"),
 ]

--- a/kanban_app/api/views.py
+++ b/kanban_app/api/views.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import status
 from kanban_app.models import Board
-from .serializers import BoardSerializer, BoardDetailSerializer, BoardUpdateSerializer, TaskSerializer
+from .serializers import BoardSerializer, BoardDetailSerializer, BoardUpdateSerializer, TaskSerializer, TaskCreateSerializer
 from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import PermissionDenied
 from django.db.models import Q
@@ -92,3 +92,22 @@ class TasksAssignedToMeView(APIView):
         tasks = Task.objects.filter(assignee=user)
         serializer = TaskSerializer(tasks, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
+    
+class TasksReviewingView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        tasks = Task.objects.filter(reviewer=request.user)
+        serializer = TaskSerializer(tasks, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class TaskCreateView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        serializer = TaskCreateSerializer(data=request.data, context={"request": request})
+        if serializer.is_valid():
+            task = serializer.save()
+            return Response(TaskSerializer(task).data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## What was added?
- Implemented `GET /api/tasks/reviewing/` endpoint
  - Returns all tasks where the current user is set as reviewer
- Implemented `POST /api/tasks/` endpoint
  - Creates a new task within a board

## Permissions
- `GET /api/tasks/reviewing/`: Only authenticated users
- `POST /api/tasks/`: Only board members can create tasks
  - `assignee` and `reviewer` must also be board members

## Responses
- 200 OK with list of review tasks (GET)
- 201 Created with full task details (POST)
- 400 Bad Request if user is not a board member or assignee/reviewer is invalid

## Status
✅ Fully tested via Postman  
✅ Validations implemented in `TaskCreateSerializer`
