### PR TITLE
Implement PATCH and DELETE

### DIFF
--- a/kanban_app/api/urls.py
+++ b/kanban_app/api/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import BoardListView, BoardDetailView, EmailCheckView, TasksAssignedToMeView, TasksReviewingView, TaskCreateView
+from .views import BoardListView, BoardDetailView, EmailCheckView, TasksAssignedToMeView, TasksReviewingView, TaskCreateView, TaskDetailView
 
 urlpatterns = [
     path('boards/', BoardListView.as_view(), name='board-list'),
@@ -8,4 +8,5 @@ urlpatterns = [
     path('tasks/assigned-to-me/', TasksAssignedToMeView.as_view(), name='tasks-assigned-to-me'),
     path("tasks/reviewing/", TasksReviewingView.as_view(), name="tasks-reviewing"),
     path("tasks/", TaskCreateView.as_view(), name="task-create"),
+    path("tasks/<int:task_id>/", TaskDetailView.as_view(), name="task-detail"),
 ]


### PR DESCRIPTION
## What was added?
- Implemented `PATCH /api/tasks/{task_id}/` endpoint
  - Updates title, description, status, priority, assignee, reviewer, due date
- Implemented `DELETE /api/tasks/{task_id}/` endpoint
  - Deletes a task by ID

## Permissions
- `PATCH`: Only board members can update tasks
  - `assignee` and `reviewer` must also be board members
- `DELETE`: Only board owners can delete tasks (no created_by field in model)

## Responses
- 200 OK with updated task (PATCH)
- 204 No Content on successful deletion (DELETE)
- 400/403/404 for invalid permissions or missing tasks

## Status
✅ Fully tested via Postman  
✅ Combined `TaskDetailView` handles both PATCH and DELETE  
✅ Clean and complete API behavior
