### PR TITLE
Implement GET, POST, DELETE endpoints for task comments

### DIFF
--- a/kanban_app/api/serializers.py
+++ b/kanban_app/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from kanban_app.models import Board, Task
+from kanban_app.models import Board, Task, Comment
 from django.contrib.auth.models import User
 
 class BoardSerializer(serializers.ModelSerializer):
@@ -189,3 +189,14 @@ class TaskUpdateSerializer(serializers.ModelSerializer):
         instance.reviewer_id = validated_data.get("reviewer_id") if "reviewer_id" in validated_data else instance.reviewer_id
         instance.save()
         return instance
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    author = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Comment
+        fields = ['id', 'created_at', 'author', 'content']
+
+    def get_author(self, obj):
+        return obj.author.get_full_name()

--- a/kanban_app/api/urls.py
+++ b/kanban_app/api/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import BoardListView, BoardDetailView, EmailCheckView, TasksAssignedToMeView, TasksReviewingView, TaskCreateView, TaskDetailView
+from .views import BoardListView, BoardDetailView, EmailCheckView, TasksAssignedToMeView, TasksReviewingView, TaskCreateView, TaskDetailView, TaskCommentsView, TaskCommentDeleteView
 
 urlpatterns = [
     path('boards/', BoardListView.as_view(), name='board-list'),
@@ -9,4 +9,6 @@ urlpatterns = [
     path("tasks/reviewing/", TasksReviewingView.as_view(), name="tasks-reviewing"),
     path("tasks/", TaskCreateView.as_view(), name="task-create"),
     path("tasks/<int:task_id>/", TaskDetailView.as_view(), name="task-detail"),
+    path('tasks/<int:task_id>/comments/', TaskCommentsView.as_view()),
+    path('tasks/<int:task_id>/comments/<int:comment_id>/', TaskCommentDeleteView.as_view()),
 ]

--- a/kanban_app/models.py
+++ b/kanban_app/models.py
@@ -26,3 +26,12 @@ class Task(models.Model):
     def comments_count(self):
         return 0
 
+
+class Comment(models.Model):
+    task = models.ForeignKey("Task", on_delete=models.CASCADE, related_name="comments")
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    content = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.author} - {self.content[:20]}"


### PR DESCRIPTION
## What was added?
- Implemented `GET /api/tasks/{task_id}/comments/`
  - Returns all comments for a task (chronologically sorted)
- Implemented `POST /api/tasks/{task_id}/comments/`
  - Creates a new comment on a task by the authenticated user
- Implemented `DELETE /api/tasks/{task_id}/comments/{comment_id}/`
  - Deletes a comment, only allowed for the comment's author

## Permissions
- User must be a member of the board the task belongs to (or the board owner)
- Only the comment's author can delete it

## Responses
- 200 OK (GET)
- 201 Created (POST)
- 204 No Content (DELETE)
- 403 Forbidden if not allowed
- 404 if task or comment not found
