### PR TITLE
tasks: POST/PATCH adjusted

### DIFF
--- a/kanban_app/api/serializers.py
+++ b/kanban_app/api/serializers.py
@@ -119,6 +119,7 @@ class TaskSerializer(serializers.ModelSerializer):
     """
     assignee = TaskUserSerializer(read_only=True)
     reviewer = TaskUserSerializer(read_only=True)
+    comments_count = serializers.SerializerMethodField()
     class Meta:
         model = Task
         fields = [
@@ -133,6 +134,9 @@ class TaskSerializer(serializers.ModelSerializer):
             'due_date',
             'comments_count'
         ]
+
+    def get_comments_count(self, obj):
+        return Comment.objects.filter(task=obj).count()
 
 class TaskCreateSerializer(serializers.ModelSerializer):
     """


### PR DESCRIPTION
## What changed
- `TaskSerializer`: added `comments_count` (calculated via related comments); keep `assignee`/`reviewer` as nested objects (`id,email,fullname`).
- `TaskCreateView.create()`: after create, return `TaskSerializer(task).data` (includes `id`, `board`, `comments_count`) with **201**.
- `TaskDetailView.update()`: validate with `TaskUpdateSerializer`, then respond using `TaskSerializer`; strip `assignee_id`/`reviewer_id` from response and omit `board` & `comments_count` for PATCH with **200**.
- No model/DB changes.

## Why
- Align `POST` and `PATCH` task responses exactly with the Endpoint Documentation so tests can use the returned `id` and expect nested user objects.

## Affected endpoints
- `POST /api/tasks/`
- `PATCH /api/tasks/{task_id}/`

## How to test
1) Authenticate: `Authorization: Token <token>`.
2) **POST** `/api/tasks/` with valid `board` and optional `assignee_id`/`reviewer_id` (must be board members).  
   **Expect:** **201** with `id`, `board`, `title`, `description`, `status`, `priority`, nested `assignee`/`reviewer`, `due_date`, `comments_count`.
3) **PATCH** `/api/tasks/{id}/` (e.g. status/priority/assignee_id/reviewer_id/due_date).  
   **Expect:** **200** with `id`, `title`, `description`, `status`, `priority`, nested `assignee`/`reviewer`, `due_date`.  
   **Not present:** `assignee_id`, `reviewer_id`, `board`, `comments_count`.
4) Errors: unknown/non-member IDs → **400**; not a board member → **403**; unauthenticated → **401**.